### PR TITLE
devectorise 'poly' for better performance

### DIFF
--- a/src/Polynomials.jl
+++ b/src/Polynomials.jl
@@ -296,7 +296,9 @@ function poly{T}(r::AbstractVector{T}, var=:x)
     c = zeros(T, n+1)
     c[1] = 1
     for j = 1:n
-        c[2:j+1] = c[2:j+1]-r[j]*c[1:j]
+        for i = 1:j
+            c[i+1] = c[i+1]-r[j]*c[i]
+        end
     end
     return Poly(reverse(c), var)
 end

--- a/src/Polynomials.jl
+++ b/src/Polynomials.jl
@@ -296,7 +296,7 @@ function poly{T}(r::AbstractVector{T}, var=:x)
     c = zeros(T, n+1)
     c[1] = 1
     for j = 1:n
-        for i = 1:j
+        for i = j:-1:1
             c[i+1] = c[i+1]-r[j]*c[i]
         end
     end


### PR DESCRIPTION
I devectorised the single vectorised line. This provides a substantial reduction in both execution time and memory usage. For specifying 5 roots, the reduction is already about a factor of 2 for time and 8 for memory. The reduction grows substantially for an increasing number of specified roots.