### PR TITLE
A Poly object can be used as a function

### DIFF
--- a/src/Polynomials.jl
+++ b/src/Polynomials.jl
@@ -11,6 +11,9 @@ export Pade, padeval
 import Base: length, endof, getindex, setindex!, copy, zero, one, convert
 import Base: show, print, *, /, //, -, +, ==, divrem, rem, eltype
 import Base: promote_rule
+if VERSION >= v"0.4"
+    import Base.call
+end
 
 eps{T}(::Type{T}) = zero(T)
 eps{F<:AbstractFloat}(x::Type{F}) = Base.eps(F)
@@ -260,6 +263,10 @@ function polyval{T,S}(p::Poly{T}, x::S)
 end
 
 polyval(p::Poly, v::AbstractVector) = map(x->polyval(p, x), v)
+
+if VERSION >= v"0.4"
+    call(p::Poly, x) = polyval(p, x)
+end
 
 function polyint{T}(p::Poly{T}, k::Number=0)
     n = length(p)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,6 +46,11 @@ sprint(show, pNULL)
 @test polyder(p3) == Poly([2,2])
 @test polyder(p1) == polyder(p0) == polyder(pNULL) == pNULL
 
+if VERSION >= v"0.4"
+    @test pN(-.125) == 276.9609375
+    @test pN([0.1, 0.2, 0.3]) == polyval(pN, [0.1, 0.2, 0.3])
+end 
+
 @test poly([-1,-1]) == p3
 @test roots(p0)==roots(p1)==roots(pNULL)==[] 
 @test roots(p2) == [-1]


### PR DESCRIPTION
Just some syntactic sugar. For julia version 0.4 or newer,
the `call` method can be overloaded and can be convenient when
using Poly objects.

This pull request, adds the new `call` method if Julia version is
0.4 or newer.

Added a test in test/runtests.jl that only gets executed if
version is 0.4 or newer.

The tests passed in both version 0.3 and 0.4.