### PR TITLE
Added support for ranges in getindex

### DIFF
--- a/src/Polynomials.jl
+++ b/src/Polynomials.jl
@@ -192,6 +192,7 @@ norm(q::Poly, args...) = norm(coeffs(q), args...)
 
 """
 getindex{T}(p::Poly{T}, i) = (i+1 > length(p.a) ? zero(T) : p.a[i+1])
+getindex{T}(p::Poly{T}, idx::AbstractArray) = map(i->p[i], idx)
 function setindex!(p::Poly, v, i)
     n = length(p.a)
     if n < i+1


### PR DESCRIPTION
It seems reasonable that if it is allowed to write
```julia
julia> p = Poly([1,2,3]);
julia> p[0], p[3]
(1,0)
```
then it should also be possible to do
```julia
julia> p[0:3]
4-element Array{Int64,1}:
 1
 2
 3
 0
```