### PR TITLE
Fix bug in `setindex!()` - closes #48

### DIFF
--- a/src/Polynomials.jl
+++ b/src/Polynomials.jl
@@ -196,7 +196,7 @@ function setindex!(p::Poly, v, i)
     n = length(p.a)
     if n < i+1
         resize!(p.a,i+1)
-        p.a[n:i] = 0
+        p.a[n+1:i] = 0
     end
     p.a[i+1] = v
     v


### PR DESCRIPTION
Fixed the bug in `setindex!()` which was resulting in clearing the
coefficient of the highest order term in the polynomial.