### PR TITLE
Fix bug in `setindex!()` - closes #48

### DIFF
--- a/src/Polynomials.jl
+++ b/src/Polynomials.jl
@@ -196,7 +196,7 @@ function setindex!(p::Poly, v, i)
     n = length(p.a)
     if n < i+1
         resize!(p.a,i+1)
-        p.a[n:i] = 0
+        p.a[n+1:i] = 0
     end
     p.a[i+1] = v
     v

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -153,3 +153,10 @@ psum = p1 + p2 - p3
 @test truncate(Poly([2,1]),reltol=1/2,abstol=0) == Poly([2])
 @test truncate(Poly([2,1]),reltol=1,abstol=0)   == Poly([0])
 @test truncate(Poly([2,1]),reltol=0,abstol=1)   == Poly([2])
+
+## setindex!
+println("Test for setindex!()")
+p1    = Poly([1,2,1])
+p1[5] = 1
+@test p1[5] == 1
+@test p1 == Poly([1,2,1,0,0,1])


### PR DESCRIPTION
Fixed the bug in `setindex!()` which was resulting in clearing the
coefficient of the highest order term in the polynomial.