### PR TITLE
Hash polynomials by their coefficients and variable

### DIFF
--- a/src/Polynomials.jl
+++ b/src/Polynomials.jl
@@ -105,6 +105,9 @@ poly(A::Matrix, var=:x) = poly(eigvals(A), var)
 poly(A::Matrix, var::AbstractString) = poly(eigvals(A), @compat Symbol(var))
 poly(A::Matrix, var::Char) = poly(eig(A)[1], @compat Symbol(var))
 
+## hash will identify equivalent polynomials
+Base.hash(f::Poly) = hash((f.a, f.var))
+
 
 include("show.jl") # display polynomials.
 


### PR DESCRIPTION
This change means that polynomials over T will be identified as the same if their coefficients and their symbol match. This proved used for using polynomials as keys for dictionaries.