### PR TITLE
v0.6 fixes; fix issue with show and NaN,Inf over C[x]

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.4
-Compat 0.7.15
+Compat 0.9.4

--- a/src/Polynomials.jl
+++ b/src/Polynomials.jl
@@ -298,8 +298,8 @@ function *{T,S}(p1::Poly{T}, p2::Poly{S})
     Poly(a,p1.var)
 end
 
-## older . operators
-if VERSION < v"0.6.0-dev"
+## older . operators, hack to avoid warning on v0.6
+dot_operators = quote    
     @compat Base.:.+{T<:Number}(c::T, p::Poly) = +(p, c)
     @compat Base.:.+{T<:Number}(p::Poly, c::T) = +(p, c)
     @compat Base.:.-{T<:Number}(p::Poly, c::T) = +(p, -c)
@@ -307,6 +307,11 @@ if VERSION < v"0.6.0-dev"
     @compat Base.:.*{T<:Number,S}(c::T, p::Poly{S}) = Poly(c * p.a, p.var)
     @compat Base.:.*{T<:Number,S}(p::Poly{S}, c::T) = Poly(p.a * c, p.var)
 end
+VERSION < v"0.6.0-dev" && eval(dot_operators)
+
+
+# are any values NaN
+hasnan(p::Poly) = reduce(|, (@compat isnan.(p.a)))
 
 function divrem{T, S}(num::Poly{T}, den::Poly{S})
     if num.var != den.var
@@ -373,6 +378,7 @@ p(4)   # 57 = 1 + 2*4 + 3*4^2
 """
 function polyval{T,S}(p::Poly{T}, x::S)
     R = promote_type(T,S)
+
     lenp = length(p)
     if lenp == 0
         return zero(R) * x
@@ -407,20 +413,20 @@ polyint{T}(p::Poly{T}) = polyint(p, 0)
 
 # if we have coefficients that have `NaN` representation
 function polyint{T<:Union{Real,Complex},S<:Number}(p::Poly{T}, k::S)
-  any(map(isnan,p.a)) && return Poly(promote_type(T,S)[NaN])
-  _polyint(p, k)
+    hasnan(p) && return Poly(promote_type(T,S)[NaN])
+    _polyint(p, k)
 end
 
 # if we have initial condition that can represent `NaN`
 function polyint{T,S<:Union{Real,Complex}}(p::Poly{T}, k::S)
-  isnan(k) && return Poly(promote_type(T,S)[NaN])
-  _polyint(p, k)
+    isnan(k) && return Poly(promote_type(T,S)[NaN])
+    _polyint(p, k)
 end
 
 # if we have both coefficients and initial condition that can take `NaN`
 function polyint{T<:Union{Real,Complex},S<:Union{Real,Complex}}(p::Poly{T}, k::S)
-  (any(map(isnan,p.a)) || isnan(k)) && return Poly(promote_type(T,S)[NaN])
-  _polyint(p, k)
+    hasnan(p) || isnan(k) && return Poly(promote_type(T,S)[NaN])
+    _polyint(p, k)
 end
 
 # otherwise, catch all
@@ -450,12 +456,12 @@ polyder(Poly([1, 3, -1]))   # Poly(3 - 2x)
 """
 # if we have coefficients that can represent `NaN`s
 function polyder{T<:Union{Real,Complex}}(p::Poly{T}, order::Int=1)
-  n = length(p)
-  order < 0       && error("Order of derivative must be non-negative")
-  order == 0      && return p
-  any(map(isnan,p.a)) && return Poly(T[NaN], p.var)
-  n <= order      && return Poly(T[], p.var)
-  _polyder(p, order)
+    n = length(p)
+    order < 0       && error("Order of derivative must be non-negative")
+    order == 0      && return p
+    hasnan(p)       && return Poly(T[NaN], p.var)
+    n <= order      && return Poly(T[], p.var)
+    _polyder(p, order)
 end
 
 # otherwise
@@ -541,7 +547,7 @@ gcd(poly([1,1,2]), poly([1,2,3])) # returns (x-1)*(x-2)
 ```
 """
 function gcd{T, S}(a::Poly{T}, b::Poly{S})
-    if all(map(abs,b.a).<=2*eps(S))
+    if reduce(&, (@compat abs.(b.a)) .<=2*eps(S))
         return a
     else
         s, r = divrem(a, b)

--- a/src/show.jl
+++ b/src/show.jl
@@ -114,8 +114,8 @@ end
   
 function printcoefficient{T}(io::IO, pj::Complex{T}, j, mimetype)
 
-    hasreal = abs(real(pj)) > 0
-    hasimag = abs(imag(pj)) > 0
+    hasreal = abs(real(pj)) > 0 || isnan(real(pj)) || isinf(real(pj))
+    hasimag = abs(imag(pj)) > 0 || isnan(imag(pj)) || isinf(imag(pj))
     
     if hasreal & hasimag
         print(io, '(')
@@ -127,6 +127,7 @@ function printcoefficient{T}(io::IO, pj::Complex{T}, j, mimetype)
     elseif hasimag
         b = imag(pj)
         (showone(T) || b != one(T)) && show(io,  mimetype, b)
+        (isnan(imag(pj)) || isinf(imag(pj))) && print(io, showop(mimetype, "*"))
         show(io, mimetype, im)
     else
         return

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -231,6 +231,8 @@ p = Poly([1, im])
 @test repr(p) == "Poly(1 + im⋅x)"
 p = Poly([1+im, 1-im, -1+im, -1 - im])# minus signs
 @test repr(p) == "Poly((1 + 1im) + (1 - 1im)⋅x - (1 - 1im)⋅x^2 - (1 + 1im)⋅x^3)"
+p = Poly([1.0, 0 + NaN*im, NaN, Inf, 0 - Inf*im]) # handle NaN or Inf appropriately
+@test repr(p) == "Poly(1.0 + NaN⋅im⋅x + NaN⋅x^2 + Inf⋅x^3 - Inf⋅im⋅x^4)"
 
 p = Poly([1,2,3])
 @test reprmime("text/latex", p) == "\$1 + 2\\cdot x + 3\\cdot x^{2}\$"


### PR DESCRIPTION
This does a few things:


* cleans up some fixes for v0.6 syntax
* bumps the Compat requirement
* fixes a bug in `show` for polys over the complex numbers that include Inf or NaN values in the coefficients.