### PR TITLE
Change indexing of `Poly`s

### DIFF
--- a/src/Polynomials.jl
+++ b/src/Polynomials.jl
@@ -206,23 +206,37 @@ transpose(p::Poly) = p
 * `getindex(p::Poly, i)`: If `p=a_n x^n + a_{n-1}x^{n-1} + ... + a_1 x^1 + a_0`, then `p[i]` returns `a_i`.
 
 """
-getindex{T}(p::Poly{T}, i) = (i+1 > length(p.a) ? zero(T) : p.a[i+1])
-getindex{T}(p::Poly{T}, idx::AbstractArray) = map(i->p[i], idx)
-function setindex!(p::Poly, v, i)
-    n = length(p.a)
-    if n < i+1
-        resize!(p.a,i+1)
-        p.a[n+1:i] = 0
-    end
-    p.a[i+1] = v
-    v
-end
-function setindex!(p::Poly, vs, idx::AbstractArray)
-    [setindex!(p, v, i) for (i,v) in zip(idx, vs)]
-    p
-end
-eachindex{T}(p::Poly{T}) = 0:(length(p)-1)
+getindex{T}(p::Poly{T}, idx::Int)                     = (idx ≥ length(p.a) ? zero(T) : p.a[idx+1])
+getindex{T}(p::Poly{T}, indices::AbstractVector{Int}) = map(idx->p[idx], indices)
+getindex{T}(p::Poly{T}, ::Colon)                      = p[0:length(p)-1]
 
+function setindex!(p::Poly, value, idx::Int)
+    n = length(p.a)
+    if n ≤ idx
+        resize!(p.a, idx+1)
+        p.a[n+1:idx] = 0
+    end
+    p.a[idx+1] = value
+    return p
+end
+
+function setindex!(p::Poly, values::AbstractVector, indices::AbstractVector{Int})
+    for (idx, value) in zip(indices, values)
+      setindex!(p, value, idx)
+    end
+    return p
+end
+
+function setindex!(p::Poly, value, indices::AbstractVector{Int})
+  for idx in indices
+    setindex!(p, value, idx)
+  end
+  return p
+end
+
+setindex!(p::Poly, values, ::Colon) = setindex!(p, values, 0:length(p)-1)
+
+eachindex{T}(p::Poly{T}) = 0:(length(p)-1)
 
 copy(p::Poly) = Poly(copy(p.a), p.var)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -165,6 +165,10 @@ p1[5] = 1
 @test p1[5] == 1
 @test p1 == Poly([1,2,1,0,0,1])
 
+p1[:] = 0
+@test p1 ≈ zero(p1)
+p1[:] = [1,2,1,0,0,1]
+@test p1 == Poly([1,2,1,0,0,1])
 
 ## elementwise operations #52
 println("Test for element-wise operations")
@@ -186,6 +190,8 @@ p1 = Poly([4,5,6])
 @test all(p1[0:end] .== [4,5,6])
 p1[0:1] = [7,8]
 @test all(p1[0:end] .== [7,8,6])
+
+@test p1[:] == coeffs(p1)
 
 ## conjugate of poly (issue #59)
 as = [im, 1, 2]
@@ -312,4 +318,3 @@ p2s = Poly([1], :s)
 
 @test Poly([0.5]) + 2 == Poly([2.5])
 @test 2 - Poly([0.5]) == Poly([1.5])
-


### PR DESCRIPTION
Changed indexing (both `getindex` and `setindex!`) of `Poly`s to add support for `::Colon` and to have compatibility with `base/array.jl`. The compatibility is about returning the changed `p::Poly` after `setindex!`s. Moreover, `setindex!` had an array comprehension before, resulting in an efficiency penalty (creating a temporary, and not using it at all).