### PR TITLE
Implemented iteration interface for `Poly`

### DIFF
--- a/src/Polynomials.jl
+++ b/src/Polynomials.jl
@@ -12,7 +12,8 @@ export degree, coeffs, variable
 export polyval, polyint, polyder, roots, polyfit
 export Pade, padeval
 
-import Base: length, endof, getindex, setindex!, copy, zero, one, convert, norm, gcd
+import Base: start, next, done, length, size, eltype
+import Base: endof, getindex, setindex!, copy, zero, one, convert, norm, gcd
 import Base: show, print, *, /, //, -, +, ==, isapprox, divrem, div, rem, eltype
 import Base: promote_rule, truncate, chop, call, conj, transpose, dot, hash
 import Base: isequal
@@ -110,15 +111,26 @@ convert{T, S<:Number}(::Type{Poly{T}}, x::AbstractArray{S}, var::SymbolLike=:x) 
 promote_rule{T, S}(::Type{Poly{T}}, ::Type{Poly{S}}) = Poly{promote_type(T, S)}
 promote_rule{T, S<:Number}(::Type{Poly{T}}, ::Type{S}) = Poly{promote_type(T, S)}
 eltype{T}(::Poly{T}) = T
-eltype{T}(::Type{Poly{T}}) = T
 
 """
 
-`legnth(p::Poly)`: return length of coefficient vector
+`length(p::Poly)`: return length of coefficient vector
 
 """
-length(p::Poly) = length(p.a)
-endof(p::Poly) = length(p) - 1
+length(p::Poly) = length(coeffs(p))
+endof(p::Poly)  = length(p) - 1
+
+start(p::Poly)        = start(coeffs(p)) - 1
+next(p::Poly, state)  = (temp = zeros(coeffs(p)); temp[state+1] = p[state]; (Poly(temp), state+1))
+done(p::Poly, state)  = state > degree(p)
+eltype{T}(::Type{Poly{T}}) = Poly{T}
+"""
+
+`size(p::Poly)`: return size of coefficient vector
+
+"""
+size(p::Poly) = size(p.a)
+size(p::Poly, i::Integer) = size(p.a, i)
 
 """
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -205,13 +205,6 @@ p2 = convert(Poly{Int64}, p1)
 p2[3] = 3
 @test p1[3] == 3
 
-
-## eltype of a Poly type
-types = [Int, UInt8, Float64]
-for t in types
-  @test t == eltype(Poly{t})
-end
-
 ## Polynomials with non-Real type
 import Base: +, *, -
 immutable Mod2 <: Number
@@ -318,3 +311,16 @@ p2s = Poly([1], :s)
 
 @test Poly([0.5]) + 2 == Poly([2.5])
 @test 2 - Poly([0.5]) == Poly([1.5])
+
+# test size
+@test size(Poly([0.5, 0.2])) == (2,)
+@test size(Poly([0.5, 0.2]), 1) == 2
+@test size(Poly([0.5, 0.2]), 1, 2) == (2,1)
+
+# test iteration
+p1 = Poly([1,2,0,3])
+for term in p1
+  @test isa(term, Poly)
+end
+
+@test eltype(typeof(p1)) == typeof(p1)


### PR DESCRIPTION
### Description
Implemented iteration interface returning terms of a given `Poly`
object.

### Motivation
According to [Julia docs][docs], Iteration interface needs `start`, `next` and `done` to be implemented. By default, Julia implements `HasLength()` for `iteratorsize(IterType)`.

Note that `eltype{T}(::Type{Poly{T}})` conflicts with that implemented by @aytekinar.

I realize that, perhaps iteration is not needed or overkill. I wanted to get your opinion about it. Looking forward to your comments.

I have also implemented `size` which I need for my `PolynomialMatrices` package.

[docs]: http://docs.julialang.org/en/stable/manual/interfaces/

### Working Example 
```julia
julia> p1 = Poly([1,2,0,3]);
julia> for term in p1
         @show term
       end
elem = Poly(1)
elem = Poly(2⋅x)
elem = Poly(0)
elem = Poly(3⋅x^3)
```